### PR TITLE
added a new key 'terminator' for choice action, added unit test for it

### DIFF
--- a/src/main/java/com/voxeo/tropo/Key.java
+++ b/src/main/java/com/voxeo/tropo/Key.java
@@ -173,6 +173,11 @@ public class Key {
         return createKey("milliseconds", milliseconds);
     }
 
+    public static Key TERMINATOR(String value) {
+
+        return createKey("terminator", value);
+    }
+    
 	public static Key createKey(String name, Object value) {
 
 		// There is an issue with JSON-LIB. When an element starts with { or [ then json-lib handles it

--- a/src/main/java/com/voxeo/tropo/actions/ChoicesAction.java
+++ b/src/main/java/com/voxeo/tropo/actions/ChoicesAction.java
@@ -4,7 +4,7 @@ import com.voxeo.tropo.Key;
 import com.voxeo.tropo.TropoException;
 import com.voxeo.tropo.annotations.ValidKeys;
 
-@ValidKeys(keys={"value","mode"})
+@ValidKeys(keys={"value","mode","terminator"})
 public class ChoicesAction extends JsonAction {
 
 	public ChoicesAction() {

--- a/src/test/java/com/voxeo/tropo/ChoicesTest.java
+++ b/src/test/java/com/voxeo/tropo/ChoicesTest.java
@@ -2,6 +2,7 @@ package com.voxeo.tropo;
 
 import static com.voxeo.tropo.Key.MODE;
 import static com.voxeo.tropo.Key.TO;
+import static com.voxeo.tropo.Key.TERMINATOR;
 import static com.voxeo.tropo.Key.VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -39,5 +40,14 @@ public class ChoicesTest {
 		} catch (TropoException te) {
 			assertEquals(te.getMessage(), "Invalid key 'to' for action");
 		}
-	}	
+	}
+	
+	@Test
+    public void testChoiceWithTerminator() {
+
+        Tropo tropo = new Tropo();
+        tropo.choices(TERMINATOR("#"));
+        
+        assertEquals(tropo.text(),"{\"tropo\":[{\"choices\":{\"terminator\":\"#\"}}]}");
+    }
 }


### PR DESCRIPTION
while using record on tropo we can use a terminator to stop the recording as stated in the tropo doc https://www.tropo.com/docs/webapi/record

"choices":{
               "terminator":"#"
          }
But ChoiceAction class didn't define a key 'terminator'. So we were not able to generate the required entity using this api