### PR TITLE
please remove the confusing key terminator

### DIFF
--- a/src/main/java/com/voxeo/tropo/actions/AskAction.java
+++ b/src/main/java/com/voxeo/tropo/actions/AskAction.java
@@ -9,7 +9,7 @@ import com.voxeo.tropo.Key;
 import com.voxeo.tropo.annotations.RequiredKeys;
 import com.voxeo.tropo.annotations.ValidKeys;
 
-@ValidKeys(keys = { "name", "text", "mode", "required", "choices", "allowSignals", "attempts", "bargein", "minConfidence", "recognizer", "terminator", "timeout", "sensitivity", "voice",
+@ValidKeys(keys = { "name", "text", "mode", "required", "choices", "allowSignals", "attempts", "bargein", "minConfidence", "recognizer", "timeout", "sensitivity", "voice",
     "interdigitTimeout" })
 @RequiredKeys(keys = { "name" })
 public class AskAction extends JsonAction {


### PR DESCRIPTION
terminator should be key of choice action, in version 0.3.1 it is in AskAction which I think is a mistake.
in version 0.4.3, should remove key terminator from AskAction as ChoiceAction have already add the key terminator which is correct corresponding to tropo webapi.

this little mistake spend us much time to find it out.