### PR TITLE
Allowing HttpClient to be passed in for session launch

### DIFF
--- a/src/main/java/com/voxeo/tropo/SessionLauncher.java
+++ b/src/main/java/com/voxeo/tropo/SessionLauncher.java
@@ -14,11 +14,23 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 
 public class SessionLauncher {
+
+	private final HttpClient client;
+
+	public SessionLauncher() {
+		client = HttpClientBuilder.create().build();
+	}
+
+	public SessionLauncher(HttpClient httpClient) {
+		if (httpClient == null) {
+			httpClient = HttpClientBuilder.create().build();
+		}
+		client = httpClient;
+	}
 
 	public TropoLaunchResult launchSession(String baseUrl, String token, Map<String, String> mapParams) {
 		
@@ -28,7 +40,6 @@ public class SessionLauncher {
 		String url = baseUrl + "sessions?action=create";
 
 		TropoParser parser = new TropoParser();
-	    HttpClient client = HttpClientBuilder.create().build();
 
 		List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
 		params.add(new BasicNameValuePair("token", token));

--- a/src/main/java/com/voxeo/tropo/Tropo.java
+++ b/src/main/java/com/voxeo/tropo/Tropo.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.client.HttpClient;
 import support.ActionSupportHandler;
 
 import com.voxeo.tropo.actions.ArrayBackedJsonAction;
@@ -303,6 +304,11 @@ public class Tropo extends ArrayBackedJsonAction {
   public TropoLaunchResult launchSession(String token, Map<String, String> params) {
 
     SessionLauncher launcher = new SessionLauncher();
+    return launcher.launchSession(baseUrl, token, params);
+  }
+
+  public TropoLaunchResult launchSession(String token, Map<String, String> params, HttpClient httpClient) {
+    SessionLauncher launcher = new SessionLauncher(httpClient);
     return launcher.launchSession(baseUrl, token, params);
   }
 

--- a/src/test/java/com/voxeo/tropo/TropoTest.java
+++ b/src/test/java/com/voxeo/tropo/TropoTest.java
@@ -5,12 +5,17 @@ import static org.junit.Assert.*;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.voxeo.tropo.actions.Do;
 import com.voxeo.tropo.mock.MockHttpServletRequest;
 import com.voxeo.tropo.mock.MockHttpServletResponse;
+
+import java.util.Collections;
 
 public class TropoTest {
 
@@ -181,8 +186,21 @@ public class TropoTest {
 		assertEquals(result.isSuccess(),true);
 		assertEquals(result.getToken(),token);
 	}
-	
-	
+
+	@Test(expected = TropoException.class)
+	public void testLaunchSessionWithProvidedHttpClientExpectTimeout() {
+
+		// This tropo test is hosted in a special Tropo username "hudson"'s account
+		String token = "bb308b34ed83d54cab226f4af7969e4c7d7d9196cdb3210b5ef0cb345616629005bfd05efe3f4409cd496ca2";
+		Tropo tropo = new Tropo();
+
+		//creates a config with 1 ms socket timeout, will not connect in time
+		RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(1).build();
+		HttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
+
+		TropoLaunchResult result = tropo.launchSession(token, Collections.EMPTY_MAP, httpClient);
+	}
+
 	@Test
 	public void testEmpty() {
 


### PR DESCRIPTION
[Addresses issue #27 ](https://github.com/tropo/tropo-webapi-java/issues/27)

*Allowing HttpClient to be passed in for session launch.